### PR TITLE
fix: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ Now you should have two command prompts, one running each bot and that's it!
 # Fair Use
 This project falls under the MIT License, so you're more than welcome to use, modify and reupload it!
 
-The project does not require you to credit myself as the bot author, but it would be very much appretiated! Have fun and happy streaming!
+The project does not require you to credit myself as the bot author, but it would be very much appreciated! Have fun and happy streaming!


### PR DESCRIPTION
According to [the Cambridge dictionary](dictionary.cambridge.org), the word "appretiate" does not exist. I found the word "appreciate" (pronounced /əˈpriː.ʃi.eɪt/) to be a proper substitute in this situation. I hope you consider merging this pull request which I think would cause a big impact in this newborn open source piece of software. Thanks.